### PR TITLE
Report JSON that failed in Error object

### DIFF
--- a/include/wapopp/detail.hpp
+++ b/include/wapopp/detail.hpp
@@ -41,10 +41,10 @@ namespace detail {
             } catch (std::exception const &) {
                 std::ostringstream os;
                 os << "Failed to parse " << field << " (" << *pos << ") to a requested type";
-                return Error{os.str()};
+                return Error{os.str(), node.dump()};
             }
         } else {
-            return Error{std::string("Missing ") + field};
+            return Error{std::string("Missing ") + field, node.dump()};
         }
     }
 

--- a/include/wapopp/wapopp.hpp
+++ b/include/wapopp/wapopp.hpp
@@ -8,7 +8,8 @@
 namespace wapopp {
 
 struct Error {
-    std::string msg;
+    std::string msg{};
+    std::string json{};
 };
 struct Record;
 using Result = std::variant<Record, Error>;

--- a/src/wapopp.cpp
+++ b/src/wapopp.cpp
@@ -52,6 +52,6 @@ void append_content(nlohmann::json const &node, std::vector<Content> &contents, 
                       data["published_date"],
                       std::move(contents)};
     } catch (nlohmann::detail::exception const& error) {
-        return Error{error.what()};
+        return Error{error.what(), line};
     }
 }


### PR DESCRIPTION
This is so we can report while parsing what has failed, e.g., for debugging.