### PR TITLE
Fallback to a default value for document fields

### DIFF
--- a/include/wapopp/detail.hpp
+++ b/include/wapopp/detail.hpp
@@ -32,6 +32,22 @@ namespace detail {
     }
 
     template <class T>
+    [[nodiscard]] auto read_field_or(nlohmann::json const &node,
+                                     std::string const &field,
+                                     T default_value) -> T
+    {
+        if (auto pos = node.find(field); pos != node.end()) {
+            try {
+                return pos->get<T>();
+            } catch (std::exception const &) {
+                return default_value;
+            }
+        } else {
+            return default_value;
+        }
+    }
+
+    template <class T>
     [[nodiscard]] auto read_mandatory_field(nlohmann::json const &node, std::string const &field)
         -> std::variant<T, Error>
     {

--- a/include/wapopp/detail.hpp
+++ b/include/wapopp/detail.hpp
@@ -41,10 +41,10 @@ namespace detail {
             } catch (std::exception const &) {
                 std::ostringstream os;
                 os << "Failed to parse " << field << " (" << *pos << ") to a requested type";
-                return Error{os.str()};
+                return Error{os.str(), node.dump()};
             }
         } else {
-            return Error{std::string("Missing ") + field};
+            return Error{std::string("Missing ") + field, node.dump()};
         }
     }
 

--- a/include/wapopp/wapopp.hpp
+++ b/include/wapopp/wapopp.hpp
@@ -8,7 +8,8 @@
 namespace wapopp {
 
 struct Error {
-    std::string msg;
+    std::string msg{};
+    std::string json{};
 };
 struct Record;
 using Result = std::variant<Record, Error>;

--- a/src/wapopp.cpp
+++ b/src/wapopp.cpp
@@ -44,12 +44,12 @@ void append_content(nlohmann::json const &node, std::vector<Content> &contents, 
             }
         }
         return Record{data["id"],
-                      data["article_url"],
-                      data["title"],
-                      data["author"],
-                      data["type"],
-                      data["source"],
-                      data["published_date"],
+                      detail::read_field_or<std::string>(data, "article_url", ""),
+                      detail::read_field_or<std::string>(data, "title", ""),
+                      detail::read_field_or<std::string>(data, "author", ""),
+                      detail::read_field_or<std::string>(data, "type", ""),
+                      detail::read_field_or<std::string>(data, "source", ""),
+                      detail::read_field_or<std::uint64_t>(data, "published_date", 0u),
                       std::move(contents)};
     } catch (nlohmann::detail::exception const& error) {
         return Error{error.what(), line};

--- a/src/wapopp.cpp
+++ b/src/wapopp.cpp
@@ -52,6 +52,6 @@ void append_content(nlohmann::json const &node, std::vector<Content> &contents, 
                       data["published_date"],
                       std::move(contents)};
     } catch (nlohmann::detail::exception const& error) {
-        return Error{error.what()};
+        return Error{error.what(), line};
     }
 }

--- a/test/test_wapopp.cpp
+++ b/test/test_wapopp.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Read record", "[unit]")
         R"({"id": "b2e89334-33f9-11e1-825f-dabc29fd7071",)"
         R"("article_url": "https://www.washingtonpost.com/truncated.html",)"
         R"("title": "Danny Coale, Jarrett Boykin are a perfect 1-2 punch for Virginia Tech",)"
-        R"("author": "Mark Giannotto",)"
+        R"("author": null,)"
         R"("published_date": 1325376562000,)"
         R"("contents": [)"
         R"({)"
@@ -79,7 +79,7 @@ TEST_CASE("Read record", "[unit]")
     REQUIRE(record.id == j["id"]);
     REQUIRE(record.url == j["article_url"]);
     REQUIRE(record.title == j["title"]);
-    REQUIRE(record.author == j["author"]);
+    REQUIRE(record.author == "");
     REQUIRE(record.published == j["published_date"]);
     REQUIRE(record.type == j["type"]);
     REQUIRE(record.source == j["source"]);


### PR DESCRIPTION
Many records in WaPo have one or another field, e.g., set for `null`. Since none other than `id` are actually mandatory, let's keep them optional.